### PR TITLE
Avoid frames from the intro sequence

### DIFF
--- a/src/frinkiac/frinkiacAccess.ts
+++ b/src/frinkiac/frinkiacAccess.ts
@@ -13,5 +13,10 @@ export async function getRandom(): Promise<RandomResponse> {
     })
   ).json()) as RandomResponse;
 
+  // Avoid returning frames that are from the first 75 seconds (intro sequence)
+  if (data.Frame.Timestamp < (75 * 24)) {
+    return getRandom();
+  }
+
   return data;
 }


### PR DESCRIPTION
Hi there,

Just a small PR to stop displaying frames from the intro sequence.

The game gave me a quote from when [homer gets hit with the car in the intro](https://frinkiac.com/caption/S05E21/16716).